### PR TITLE
Adds option to use original SOAP message tag names

### DIFF
--- a/lib/soapforce.rb
+++ b/lib/soapforce.rb
@@ -4,6 +4,7 @@ require "soapforce/version"
 require "soapforce/configuration"
 
 require "soapforce/client"
+require "soapforce/result"
 require "soapforce/query_result"
 require "soapforce/sobject"
 

--- a/lib/soapforce/query_result.rb
+++ b/lib/soapforce/query_result.rb
@@ -4,17 +4,32 @@ module Soapforce
 
     attr_reader :raw_result
 
-    def initialize(result_hash={})
-      @raw_result = result_hash
+    def initialize(result={})
+      if result.is_a?(Soapforce::Result)
+        @raw_result = result.to_hash
+      else
+        @raw_result = result
+      end
+
       @result_records = [] # Default for 0 size response.
-      if @raw_result[:size].to_i == 1
-        @result_records = [@raw_result[:records]]
-      elsif @raw_result[:records]
-        @result_records = @raw_result[:records]
+      @key_type = @raw_result.key?(:size) ? :symbol : :string
+
+      records_key = key_name("records")
+
+      if @raw_result[records_key]
+        @result_records = @raw_result[records_key]
+        # Single records come back as a Hash. Wrap in array.
+        if @result_records.is_a?(Hash)
+          @result_records = [@result_records]
+        end
       end
 
       # Convert to SObject type.
       @result_records.map! {|hash| SObject.new(hash) }
+    end
+
+    def records
+      @result_records
     end
 
     # Implmentation for Enumerable mix-in.
@@ -22,20 +37,34 @@ module Soapforce
       @result_records.each(&block)
     end
 
+    def map(&block)
+      @result_records.map(&block)
+    end
+
     def size
-      @raw_result[:size].to_i || 0
+      @raw_result[key_name("size")].to_i || 0
     end
 
     def done?
-      @raw_result[:done] || true
+      @raw_result[key_name("done")] || true
     end
 
     def query_locator
-      @raw_result[:query_locator]
+      @raw_result[key_name("queryLocator")]
     end
 
     def method_missing(method, *args, &block)
-      @result_records.send(method, *args, &block)
+      if @result_records.respond_to?(method)
+        @result_records.send(method, *args, &block)
+      end
+    end
+
+    def key_name(key)
+      if @key_type == :symbol
+        key.is_a?(String) ? key.snakecase.to_sym : key
+      else
+        key.to_s
+      end
     end
   end
 

--- a/lib/soapforce/result.rb
+++ b/lib/soapforce/result.rb
@@ -1,0 +1,36 @@
+module Soapforce
+  class Result
+    extend Forwardable
+
+    attr_reader :raw_hash
+
+    def_delegators :@raw_hash, :key?, :has_key?, :each, :map, :to_hash
+
+    def initialize(result_hash={})
+      @raw_hash = result_hash
+    end
+
+    def [](index)
+      # If index is a symbol, try :field_name, "fieldName", "field_name"
+      if index.is_a?(Symbol)
+        if @raw_hash.key?(index)
+          @raw_hash[index]
+        elsif index.to_s.include?('_')
+          camel_key = index.to_s.gsub(/\_(\w{1})/) {|cap| cap[1].upcase }
+          @raw_hash[camel_key]
+        else
+          @raw_hash[index.to_s]
+        end
+      elsif index.is_a?(String)
+        # If index is a String, try fieldName, :fieldName, :field_name
+        if @raw_hash.key?(index)
+          @raw_hash[index]
+        elsif @raw_hash.key?(index.to_sym)
+          @raw_hash[index.to_sym]
+        else
+          @raw_hash[index.snakecase.to_sym]
+        end
+      end
+    end
+  end
+end

--- a/lib/soapforce/sobject.rb
+++ b/lib/soapforce/sobject.rb
@@ -4,19 +4,36 @@ module Soapforce
 
     def initialize(hash)
       @raw_hash = hash || {}
+      id_key = @raw_hash.key?(:id) ? :id : 'Id'
+
+      # For some reason the Id field is coming back twice and stored in an array.
+      if @raw_hash[id_key].is_a?(Array)
+        @raw_hash[id_key] = @raw_hash[id_key].compact.uniq
+        # Remove empty id array if nothing exists.
+        if @raw_hash[id_key].empty?
+          @raw_hash.delete(id_key)
+        elsif @raw_hash[id_key].size == 1
+          @raw_hash[id_key] = @raw_hash[id_key].first
+        end
+      end
     end
 
-    # For some reason the Id field is coming back twice and stored in an array.
     def Id
-      @raw_hash[:id].is_a?(Array) ? @raw_hash[:id].first : @raw_hash[:id]
+      @raw_hash[:id] || @raw_hash['Id']
     end
 
     def [](index)
-      @raw_hash[index.to_sym]
+      val = @raw_hash[index]
+
+      # When fetching a child relationship, wrap it in QueryResult
+      if val.is_a?(Hash) && (val.has_key?(:records) || val.has_key?("records"))
+        val = QueryResult.new(val)
+      end
+      val
     end
 
     def []=(index, value)
-      @raw_hash[index.to_sym] = value
+      @raw_hash[index] = value
     end
 
     def has_key?(key)
@@ -25,31 +42,28 @@ module Soapforce
 
     # Allows method-like access to the hash using camelcase field names.
     def method_missing(method, *args, &block)
-
+      # Check string keys first, original and downcase
       string_method = method.to_s
+
+      if raw_hash.key?(string_method)
+        return self[string_method]
+      elsif raw_hash.key?(string_method.downcase)
+        return self[string_method.downcase]
+      end
+
       if string_method =~ /[A-Z+]/
-        string_method = underscore(string_method)
+        string_method = string_method.snakecase
       end
 
       index = string_method.downcase.to_sym
-      # First return local hash entry.
-      return raw_hash[index] if raw_hash.has_key?(index)
+      # Check symbol key and return local hash entry.
+      return self[index] if raw_hash.has_key?(index)
       # Then delegate to hash object.
       if raw_hash.respond_to?(method)
         return raw_hash.send(method, *args)
       end
       # Finally return nil.
       nil
-    end
-
-    protected
-
-    def underscore(str)
-      str.gsub(/::/, '/').
-        gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
-        gsub(/([a-z\d])([A-Z])/,'\1_\2').
-        tr("-", "_").
-        downcase
     end
 
   end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Soapforce do
+describe Soapforce::Configuration do
 
   after do
     Soapforce.instance_variable_set :@configuration, nil

--- a/spec/lib/query_result_spec.rb
+++ b/spec/lib/query_result_spec.rb
@@ -60,6 +60,7 @@ describe Soapforce::QueryResult do
       }
 
       it { expect(subject.size).to eq 2 }
+      it { expect(subject.records).to be_an(Array) }
       it { expect(subject.query_locator).to be_nil }
       it { expect(subject).to be_done }
 
@@ -72,6 +73,17 @@ describe Soapforce::QueryResult do
         end
         expect(count).to be(2)
       end
+
+      it "#map" do
+        count = 0
+        subject.map do |obj|
+          count +=1
+          expect(obj[:id]).to eq count
+          expect(obj.Id).to eq count
+        end
+        expect(count).to be(2)
+      end
+
     end
 
   end

--- a/spec/lib/result_spec.rb
+++ b/spec/lib/result_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Soapforce::Result do
+
+  describe 'symbol keys' do
+    subject { Soapforce::Result.new({new_workitem_ids: 12345, success: true}) }
+
+    it { expect(subject[:new_workitem_ids]).to eq 12345 }
+    it { expect(subject["newWorkitemIds"]).to eq 12345 }
+    it { expect(subject[:success]).to eq true }
+    it { expect(subject["success"]).to eq true }
+  end
+
+  describe 'string keys' do
+    subject { Soapforce::Result.new({"newWorkitemIds" => 12345, "success" => true}) }
+
+    it { expect(subject[:new_workitem_ids]).to eq 12345 }
+    it { expect(subject["newWorkitemIds"]).to eq 12345 }
+    it { expect(subject[:success]).to eq true }
+    it { expect(subject["success"]).to eq true }
+  end
+
+
+end

--- a/spec/lib/sobject_spec.rb
+++ b/spec/lib/sobject_spec.rb
@@ -2,8 +2,23 @@ require 'spec_helper'
 
 describe Soapforce::SObject do
 
-  describe 'empty object' do
-    subject { Soapforce::SObject.new(id: [1, 1], name: "testing", stage_name: "Prospecting") }
+  describe 'symbol snakecase keys' do
+    subject {
+      Soapforce::SObject.new({
+        id: [1, 1],
+        name: "testing",
+        stage_name: "Prospecting",
+        opportunity_line_items: {
+          done: true,
+          query_locator: nil,
+          size: 2,
+          records: [
+            {id: 1, name: "Opportunity 1", stage_name: "Prospecting"},
+            {id: 2, name: "Opportunity 2", stage_name: "Closed Won"}
+          ]
+        }
+      })
+    }
 
     context "should have defaults" do
       it { expect(subject.Id).to eq 1 }
@@ -11,7 +26,7 @@ describe Soapforce::SObject do
       it { expect(subject.StageName).to eq "Prospecting" }
       it { expect(subject.InvalidField).to be_nil }
 
-      it { expect(subject[:id]).to eq [1, 1] }
+      it { expect(subject[:id]).to eq 1 }
       it { expect(subject[:name]).to eq "testing" }
       it { expect(subject[:stage_name]).to eq "Prospecting" }
       it { expect(subject[:no_field]).to be_nil }
@@ -26,6 +41,23 @@ describe Soapforce::SObject do
       end
     end
 
+    context "child relationship" do
+      it "returns records as QueryResult" do
+        items = subject.OpportunityLineItems
+
+        expect(items).to be_an_instance_of(Soapforce::QueryResult)
+        expect(items.size).to eq 2
+        expect(items).to be_done
+
+        number = 1
+        subject.OpportunityLineItems.each do |sobject|
+          expect(sobject.Id).to eq number
+          expect(sobject.Name).to eq "Opportunity #{number}"
+          number += 1
+        end
+      end
+    end
+
     context "respond to hash methods" do
 
       it "should has_key?" do
@@ -35,10 +67,94 @@ describe Soapforce::SObject do
       end
 
       it "should return keys" do
-        expect(subject.keys).to eq [:id, :name, :stage_name]
+        expect(subject.keys).to eq [:id, :name, :stage_name, :opportunity_line_items]
       end
     end
 
   end
+
+  describe 'string keys' do
+    subject {
+      Soapforce::SObject.new(
+        "Id" => [1, 1],
+        "Name" => "testing",
+        "StageName" => "Prospecting",
+        "OpportunityLineItems" => {
+          "done" => true,
+          "queryLocator" => nil,
+          "size" => 2,
+          "records" => [
+            {"Id" => 1, "Name" => "Opportunity 1", "StageName" => "Prospecting"},
+            {"Id" => 2, "Name" => "Opportunity 2", "StageName" => "Closed Won"}
+          ]
+        }
+      )
+    }
+
+    context "should have defaults" do
+      it { expect(subject.Id).to eq 1 }
+      it { expect(subject.Name).to eq "testing" }
+      it { expect(subject.StageName).to eq "Prospecting" }
+      it { expect(subject.InvalidField).to be_nil }
+
+      it { expect(subject["Id"]).to eq 1 }
+      it { expect(subject["Name"]).to eq "testing" }
+      it { expect(subject["StageName"]).to eq "Prospecting" }
+      it { expect(subject["NoField"]).to be_nil }
+    end
+
+    context "assignment" do
+      it "should assign through hash index" do
+        expect(subject["nothing"]).to be_nil
+        subject["nothing"] = "New Value"
+        expect(subject["nothing"]).to eq "New Value"
+        expect(subject.Nothing).to eq "New Value"
+      end
+    end
+
+    context "respond to hash methods" do
+
+      it "should has_key?" do
+        expect(subject).to have_key("Name")
+        expect(subject).to have_key("StageName")
+        expect(subject).to_not have_key("nothing")
+      end
+
+      it "should return keys" do
+        expect(subject.keys).to eq ["Id", "Name", "StageName", "OpportunityLineItems"]
+      end
+    end
+
+    context "child relationship" do
+      it "returns records as QueryResult" do
+        items = subject.OpportunityLineItems
+        expect(items).to be_an_instance_of(Soapforce::QueryResult)
+        expect(items.size).to eq 2
+        expect(items).to be_done
+
+        number = 1
+        subject.OpportunityLineItems.each do |sobject|
+          expect(sobject.Id).to eq number
+          expect(sobject.Name).to eq "Opportunity #{number}"
+          number += 1
+        end
+      end
+    end
+
+  end
+
+  describe 'empty id field' do
+    subject { Soapforce::SObject.new({ id: [nil, nil], name: "testing", stage_name: "Prospecting" }) }
+
+    context "should have defaults" do
+      it { expect(subject).to_not have_key(:id) }
+      it { expect(subject.Name).to eq "testing" }
+      it { expect(subject.StageName).to eq "Prospecting" }
+      it { expect(subject.InvalidField).to be_nil }
+      it { expect(subject.to_hash).to eq({:name=>"testing", :stage_name=>"Prospecting"}) }
+    end
+  end
+
+
 
 end


### PR DESCRIPTION
This is the behavior I wish I would have started with.  Savon2 by default converts tags to snakecase and I want to use the real field names that Salesforce is returning.  As a transition from old to new I need the ability to make tag names configurable.  My goal is to one day remove snakecase support.