### PR TITLE
Foreign key relationships using external IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,16 @@ client.update('Account', Id: '006A000000Lbiiz', Name: 'Whizbang Corp')
 ```ruby
 # Update the record with external ID of 12
 client.upsert('Account', 'External__c', External__c: 12, Name: 'Foobar')
-# => {id: '006A000000Lbiiz', success: => true, created: false}
+# => {id: '006A000000Lbiiz', success: true, created: false}
 ```
+
+You may also set up Lookup or Master-Detail relationships by specifying the external ID of the related object like this -
+
+```
+# Update the record with external ID of 12 and relate it to another object with external ID of 13
+client.upsert('Account', 'External__c', 'Foo_Relation__r.External__c' => 13)
+# => {id: '006A000000Lbiiz', success: true, created: false}
+``` 
 
 ### destroy
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ You may also set up Lookup or Master-Detail relationships by specifying the exte
 
 ```ruby
 # Update the record with external ID of 12 and relate it to another object with external ID of 13
-client.upsert('Account', 'External__c', 'Foo_Relation__r.External__c' => 13)
+client.upsert('Account', 'External__c', External__c: 12, Name: 'Foobar', 'Foo_Relation__r.External__c' => 13)
 # => {id: '006A000000Lbiiz', success: true, created: false}
 ```
 

--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ client.upsert('Account', 'External__c', External__c: 12, Name: 'Foobar')
 
 You may also set up Lookup or Master-Detail relationships by specifying the external ID of the related object like this -
 
-```
+```ruby
 # Update the record with external ID of 12 and relate it to another object with external ID of 13
 client.upsert('Account', 'External__c', 'Foo_Relation__r.External__c' => 13)
 # => {id: '006A000000Lbiiz', success: true, created: false}
-``` 
+```
 
 ### destroy
 

--- a/lib/soapforce/client.rb
+++ b/lib/soapforce/client.rb
@@ -598,9 +598,6 @@ module Soapforce
           value = obj.delete(key)
           obj.update(rel_name => {:"@xsi:type" => referenced_sobject, target_field => value }) unless value.nil?
         end
-
-        logger.debug "$$$$ SOBJECTS $$$$"
-        logger.debug sobjects
       end
     end
   end

--- a/lib/soapforce/client.rb
+++ b/lib/soapforce/client.rb
@@ -583,7 +583,8 @@ module Soapforce
       metadata = describe(sobject_type)
 
       # Get only the keys that contain relationships described with dot-syntax
-      sobjects.first.keys.select { |key| key =~ /\./ }.each do |key|
+      keys = sobjects.map(&:keys).flatten.uniq.select { |key| key =~ /\./ }
+      keys.each do |key|
 
         rel_name, target_field = key.split('.')
 
@@ -593,11 +594,13 @@ module Soapforce
 
         referenced_sobject = field_metadata[:reference_to]
 
-        sobjects.map! do |obj|
+        sobjects.each do |obj|
           value = obj.delete(key)
-          {rel_name => {:"@xsi:type" => referenced_sobject, target_field => value }}.merge(obj) unless value.nil?
+          obj.update(rel_name => {:"@xsi:type" => referenced_sobject, target_field => value }) unless value.nil?
         end
 
+        logger.debug "$$$$ SOBJECTS $$$$"
+        logger.debug sobjects
       end
     end
   end


### PR DESCRIPTION
I wrote some code that handles this concept (described [here](http://www.pocketsoap.com/weblog/2008/09/1824.html) and other random places on the web).

The basic idea is, during an `upsert` call, you know the Salesforce external identifier of your record(s), but what if you want to also set up relationships using the external ID of the object on the other side of the relation?

It turns out Salesforce supports this concept. Originally, in my project that makes use of this gem, I figured out how to build a hash that would eventually translate into the requisite nested XML element that the SOAP API would understand.

But I figured, that would be nifty if the client knew how to do that!

The approach is three-fold -
1. Allow a new syntax for representing the relationship. The relationship name, followed by a dot, followed by the external ID field on the related object. In the case of custom relationships, it uses the double-underscore “r” syntax (__r). This is reminiscent of how Apex and SOQL handle related object lookups. For instance -

``` ruby
data = {
  "Ext_ID__c" => 1234,
  "FooField__c" => "BarValue"
  "FooRelation__r.Ext_ID__c" => 5678
}
```
1. In the `subjects_hash` method on the `Client` class, perform a check for input hash keys containing this ‘dot’ syntax. If so, call the `related_external_id_references` routine.
2. In the `related_external_id_references` routine, perform a `describe` call on the sObject type in question. Split the dot-syntax hash key into parts. The first part is the relationship name, which is used to look in the sObject metadata for the target object’s actual name (since the relationship name can differ from the sObject name). Then build the proper nested hash.

I’ll be using my forked version for my project, but feel free to merge this in if you would like to add this functionality to the main gem!

I also added a snippet to the Readme describing how to use.
