### PR TITLE
Require forwardable explicitly

### DIFF
--- a/lib/soapforce.rb
+++ b/lib/soapforce.rb
@@ -1,4 +1,5 @@
-require 'savon'
+require "forwardable"
+require "savon"
 
 require "soapforce/version"
 require "soapforce/configuration"


### PR DESCRIPTION
Version 0.5.0 has introduced a bug which prevents soapforce to be loaded properly in some cases by using Forwardable module without requiring it explicitly.

Irb output:
```
soapforce|master ⇒ irb
irb(main):001:0> require "soapforce"
NameError: uninitialized constant Soapforce::Result::Forwardable
  from /Users/kamil/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/soapforce-0.5.0/lib/soapforce/result.rb:3:in `<class:Result>'
  from /Users/kamil/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/soapforce-0.5.0/lib/soapforce/result.rb:2:in `<module:Soapforce>'
  from /Users/kamil/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/soapforce-0.5.0/lib/soapforce/result.rb:1:in `<top (required)>'
  from /Users/kamil/.rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  from /Users/kamil/.rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  from /Users/kamil/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/soapforce-0.5.0/lib/soapforce.rb:7:in `<top (required)>'
  from /Users/kamil/.rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:127:in `require'
  from /Users/kamil/.rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:127:in `rescue in require'
  from /Users/kamil/.rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:40:in `require'
  from (irb):1
  from /Users/kamil/.rbenv/versions/2.3.0/bin/irb:11:in `<main>'
irb(main):002:0> require "forwardable"
=> true
irb(main):003:0> require "soapforce"
=> true
```

Adding simple `require "forwardable"` fixes the bug.
Similar issue in monetize https://github.com/RubyMoney/monetize/issues/44