### PR TITLE
WIP add batch merge and batch convert lead

### DIFF
--- a/lib/soapforce/client.rb
+++ b/lib/soapforce/client.rb
@@ -380,6 +380,16 @@ module Soapforce
       leads = attributes.is_a?(Array) ? attributes : [attributes]
       call_soap_api(:convert_lead, leadConverts: leads)
     end
+    
+    # convert_lead_requests - array of ConvertLeadRequest
+    # returns array of Soapforce::Result
+    def batch_convert_lead!(convert_lead_requests)
+      r = call_soap_api(
+        :convert_lead,
+        request: convert_lead_requests.map(&:request_hash)
+      )
+      [r].flatten
+    end
 
     # Public: Merges records together
     #
@@ -401,6 +411,16 @@ module Soapforce
           recordToMergeIds: ids
         }
       )
+    end
+    
+    # merge_requests - array of MergeRequest
+    # returns array of soapforce result
+    def batch_merge!(merge_requests)
+      r = call_soap_api(
+        :merge,
+        request: merge_requests.map(&:request_hash)
+      )
+      [r].flatten
     end
 
     # Public: Merges records together

--- a/lib/soapforce/convert_lead_request.rb
+++ b/lib/soapforce/convert_lead_request.rb
@@ -1,0 +1,13 @@
+module Soapforce
+  ConvertLeadRequest = Struct.new(:lead_id, :contact_id, :account_id, :convert_status) do
+    def request_hash
+      {
+        leadId:self.lead_id,
+        contactId:self.contact_id,
+        accountId: self.account_id,
+        convertedStatus: self.convert_status,
+        doNotCreateOpportunity:true
+      }
+    end
+  end
+end

--- a/lib/soapforce/merge_request.rb
+++ b/lib/soapforce/merge_request.rb
@@ -1,0 +1,16 @@
+module Soapforce
+  MergeRequest = Struct.new(:sobject_type,:master_id,:other_ids) do
+    def master_record_hash
+      {
+        'Id' => self.master_id
+      }
+    end
+
+    def request_hash
+      {
+        masterRecord: master_record_hash.merge(:'@xsi:type' => sobject_type),
+        recordToMergeIds: self.other_ids
+      }
+    end
+  end
+end


### PR DESCRIPTION
Does not raise exception on errors, must check individual
Soapforce::Result in array

Use array  provided structs for each requested batch operation