### PR TITLE
Add Log Filter Options for Savon

### DIFF
--- a/lib/soapforce/client.rb
+++ b/lib/soapforce/client.rb
@@ -30,7 +30,7 @@ module Soapforce
       @ssl_version = options[:ssl_version] || :TLSv1_2
 
       # For security purposes, default to filtering out passwords
-      # To override this, the options hash can include: filters => [] 
+      # To override this, include the following in the opportunities hash: filters => [] 
       @filters = options[:filters] || [:password]
 
       if options[:tag_style] == :raw

--- a/lib/soapforce/client.rb
+++ b/lib/soapforce/client.rb
@@ -29,6 +29,10 @@ module Soapforce
       # Due to SSLv3 POODLE vulnerabilty and disabling of TLSv1, use TLSv1_2
       @ssl_version = options[:ssl_version] || :TLSv1_2
 
+      # For security purposes, default to filtering out passwords
+      # To override this, the options hash can include: filters => [] 
+      @filters = options[:filters] || [:password]
+
       if options[:tag_style] == :raw
         @tag_style = :raw
         @response_tags = lambda { |key| key }
@@ -39,7 +43,7 @@ module Soapforce
 
       # Override optional Savon attributes
       savon_options = {}
-      %w(read_timeout open_timeout proxy raise_errors filters).each do |prop|
+      %w(read_timeout open_timeout proxy raise_errors).each do |prop|
         key = prop.to_sym
         savon_options[key] = options[key] if options.key?(key)
       end
@@ -50,6 +54,7 @@ module Soapforce
         convert_request_keys_to: :none,
         convert_response_tags_to: @response_tags,
         pretty_print_xml: true,
+        filters: @filters,
         logger: @logger,
         log: (@logger != false),
         endpoint: @login_url,
@@ -102,6 +107,7 @@ module Soapforce
         convert_request_keys_to: :none,
         convert_response_tags_to: @response_tags,
         logger: @logger,
+        filters: @filters,
         log: (@logger != false),
         endpoint: @server_url,
         ssl_version: @ssl_version # Sets ssl_version for HTTPI adapter

--- a/lib/soapforce/client.rb
+++ b/lib/soapforce/client.rb
@@ -39,7 +39,7 @@ module Soapforce
 
       # Override optional Savon attributes
       savon_options = {}
-      %w(read_timeout open_timeout proxy raise_errors).each do |prop|
+      %w(read_timeout open_timeout proxy raise_errors filters).each do |prop|
         key = prop.to_sym
         savon_options[key] = options[key] if options.key?(key)
       end

--- a/soapforce.gemspec
+++ b/soapforce.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "savon", ">= 2.3.0", '< 3.0.0'
 
   spec.add_development_dependency 'rspec', '>= 2.14.0', '< 4.0.0'
-  spec.add_development_dependency 'webmock', '2.3.2'
+  spec.add_development_dependency 'webmock', '>=2.3.2'
   spec.add_development_dependency 'simplecov', '>= 0.9.0', '< 1.0.0'
 end

--- a/soapforce.gemspec
+++ b/soapforce.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "savon", ">= 2.3.0", '< 3.0.0'
 
   spec.add_development_dependency 'rspec', '>= 2.14.0', '< 4.0.0'
-  spec.add_development_dependency 'webmock', '2.3.2'#'>= 1.17.0', '< 2.0.0'
+  spec.add_development_dependency 'webmock', '2.3.2'
   spec.add_development_dependency 'simplecov', '>= 0.9.0', '< 1.0.0'
 end

--- a/soapforce.gemspec
+++ b/soapforce.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "savon", ">= 2.3.0", '< 3.0.0'
 
   spec.add_development_dependency 'rspec', '>= 2.14.0', '< 4.0.0'
-  spec.add_development_dependency 'webmock', '>= 1.17.0', '< 2.0.0'
+  spec.add_development_dependency 'webmock', '2.3.2'#'>= 1.17.0', '< 2.0.0'
   spec.add_development_dependency 'simplecov', '>= 0.9.0', '< 1.0.0'
 end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -18,7 +18,7 @@ describe Soapforce::Client do
       stub = stub_login_request({with_body: body})
       stub.to_return(:status => 200, :body => fixture("login_response")) #, :headers => {})
 
-      subject.login(username: 'testing', password: 'password_and_token')
+      subject.login(username: 'testing', password: 'password_and_token', filters: [])
     end
 
     it "authenticates with session_id and instance_url" do
@@ -319,7 +319,7 @@ describe Soapforce::Client do
 
   describe "#update" do
     before(:each) do
-      @body = "<tns:update><tns:sObjects><ins0:type>Opportunity</ins0:type><ins0:Id>003ABCDE</ins0:Id><tns:Name>SOAPForce Opportunity</tns:Name><tns:CloseDate>2013-08-12</tns:CloseDate><tns:StageName>Closed Won</tns:StageName></tns:sObjects></tns:update>"
+      @body = "<tns:update><tns:sObjects><ins0:type>Opportunity</ins0:type><tns:Id>003ABCDE</tns:Id><tns:Name>SOAPForce Opportunity</tns:Name><tns:CloseDate>2013-08-12</tns:CloseDate><tns:StageName>Closed Won</tns:StageName></tns:sObjects></tns:update>"
       @params = { Id: '003ABCDE', Name: "SOAPForce Opportunity", CloseDate: '2013-08-12', StageName: 'Closed Won' }
     end
 
@@ -356,7 +356,7 @@ describe Soapforce::Client do
 
   describe "#upsert" do
     before(:each) do
-      @body = "<tns:upsert><tns:externalIDFieldName>External_Id__c</tns:externalIDFieldName><tns:sObjects><ins0:type>Opportunity</ins0:type><tns:Name>New Opportunity</tns:Name><tns:CloseDate>2013-08-12</tns:CloseDate><tns:StageName>Prospecting</tns:StageName></tns:sObjects><tns:sObjects><ins0:type>Opportunity</ins0:type><ins0:Id>003ABCDE</ins0:Id><tns:Name>Existing Opportunity</tns:Name><tns:CloseDate>2013-08-12</tns:CloseDate><tns:StageName>Closed Won</tns:StageName></tns:sObjects></tns:upsert>"
+      @body = "<tns:upsert><tns:externalIDFieldName>External_Id__c</tns:externalIDFieldName><tns:sObjects><ins0:type>Opportunity</ins0:type><tns:Name>New Opportunity</tns:Name><tns:CloseDate>2013-08-12</tns:CloseDate><tns:StageName>Prospecting</tns:StageName></tns:sObjects><tns:sObjects><ins0:type>Opportunity</ins0:type><tns:Id>003ABCDE</tns:Id><tns:Name>Existing Opportunity</tns:Name><tns:CloseDate>2013-08-12</tns:CloseDate><tns:StageName>Closed Won</tns:StageName></tns:sObjects></tns:upsert>"
       @objects = [
         { Name: "New Opportunity", CloseDate: '2013-08-12', StageName: 'Prospecting' },
         { Id: '003ABCDE', Name: "Existing Opportunity", CloseDate: '2013-08-12', StageName: 'Closed Won' }

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -18,7 +18,7 @@ describe Soapforce::Client do
       stub = stub_login_request({with_body: body})
       stub.to_return(:status => 200, :body => fixture("login_response")) #, :headers => {})
 
-      subject.login(username: 'testing', password: 'password_and_token', filters: [])
+      subject.login(username: 'testing', password: 'password_and_token')
     end
 
     it "authenticates with session_id and instance_url" do


### PR DESCRIPTION
Added option to include filters for logs to Savon, to take advantage of https://github.com/savonrb/savon/blob/e76ecc00b84b998b012ecc33b55ca1edd443ec55/lib/savon/log_message.rb#L7 and thereby allow us to filter out passwords (as in https://github.com/savonrb/savon/blob/e76ecc00b84b998b012ecc33b55ca1edd443ec55/spec/savon/log_message_spec.rb#L44)